### PR TITLE
⏺ feat(buttcrack): add BUTTCRACK — Batch Utility To Transfer Cluster Resources And Configs Kit

### DIFF
--- a/buttcrack/Cargo.toml
+++ b/buttcrack/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "buttcrack"
+version = "0.1.0"
+edition = "2021"
+authors = ["George Agriogiannis <george.agriogiannis2@suse.com>"]
+description = "Batch Utility To Transfer Cluster Resources And Configs Kit"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1.0"
+chrono = "0.4"
+clap = { version = "4.0", features = ["derive", "env"] }
+flate2 = "1.0"
+tar = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+walkdir = "2.0"

--- a/buttcrack/README.md
+++ b/buttcrack/README.md
@@ -1,0 +1,292 @@
+# 🍑 BUTTCRACK - Batch Utility To Transfer Cluster Resources And Configs Kit
+
+> **Don't let your cluster data slip through the cracks!** 🕵️
+
+A blazingly fast 🦀 Rust-powered tool that collects arbitrary host paths and archives them into a compressed bundle for upload and investigation.
+
+## ✨ Features
+
+📁 **Path Flexible** - Collect any directory or file path from the host, not just predefined ones
+🗜️ **Compressed Archives** - Creates `.tar.gz` archives with timestamped names for easy tracking
+🔒 **Read-Only by Design** - Input paths are always mounted read-only in container mode
+🐳 **Container Ready** - Runs as a privileged container with explicit host path mounts and SELinux support
+⚙️ **Env Var Support** - Every flag has a `BC_*` env var equivalent for Ansible-driven automation
+🔌 **stack-validation Native** - Output naming and archive format designed to plug directly into existing Ansible upload pipelines
+🦀 **Fast & Safe** - Built with Rust for reliable, predictable behaviour under privileged execution
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- 🐳 **Podman** installed on the host
+- 📁 **Read access** to the paths you want to collect
+- 📤 **Write access** to the output directory
+
+### Quick Start with Container
+
+```bash
+# Collect a single path
+podman run --rm --privileged \
+           -v /var/lib/rancher/rke2/server/db/etcd:/var/lib/rancher/rke2/server/db/etcd:ro \
+           -v /tmp:/tmp \
+           registry.opensuse.org/isv/suse/edge/support-tools/images/buttcrack:latest \
+           --paths /var/lib/rancher/rke2/server/db/etcd \
+           --output /tmp
+
+# Collect multiple paths
+podman run --rm --privileged \
+           -v /var/lib/rancher/rke2/server/db/etcd:/var/lib/rancher/rke2/server/db/etcd:ro \
+           -v /var/log/pods:/var/log/pods:ro \
+           -v /tmp:/tmp \
+           registry.opensuse.org/isv/suse/edge/support-tools/images/buttcrack:latest \
+           --paths /var/lib/rancher/rke2/server/db/etcd,/var/log/pods \
+           --output /tmp
+```
+
+**Note:** Each input path must be explicitly bind-mounted into the container with `:ro`. The output directory must be mounted with write access. The `:Z` flag may be required on SELinux systems — see the [SELinux note](#-troubleshooting) below.
+
+### Building Custom Container Image
+
+```bash
+# Build the container image
+podman build -t buttcrack:custom .
+
+# Run your custom image
+podman run --rm --privileged \
+           -v /var/lib/rancher/rke2/server/db/etcd:/var/lib/rancher/rke2/server/db/etcd:ro \
+           -v /tmp:/tmp \
+           buttcrack:custom \
+           --paths /var/lib/rancher/rke2/server/db/etcd \
+           --output /tmp
+```
+
+### Installation from Source
+
+**Prerequisites:**
+- 🦀 **Rust 1.70+** (install via [rustup](https://rustup.rs/))
+
+```bash
+# Clone the repository
+git clone https://github.com/suse-edge/support-tools.git
+cd support-tools/buttcrack
+
+# Build the tool
+cargo build --release
+
+# Run it
+cargo run -- --paths /var/lib/rancher/rke2/server/db/etcd --output /tmp
+```
+
+## 📖 Usage
+
+### Basic Usage
+
+```bash
+# Collect a single path
+buttcrack --paths /var/lib/rancher/rke2/server/db/etcd --output /tmp
+
+# Collect multiple paths (comma-separated)
+buttcrack --paths /var/lib/rancher/rke2/server/db/etcd,/var/log/pods --output /tmp
+
+# Using environment variables
+BC_PATHS=/var/lib/rancher/rke2/server/db/etcd BC_OUTPUT=/tmp buttcrack
+```
+
+### Command Line Options
+
+| Option | Short | Env var | Description | Default |
+|--------|-------|---------|-------------|---------|
+| `--paths` | `-p` | `BC_PATHS` | **Required** Comma-separated list of host paths to collect | - |
+| `--output` | `-o` | `BC_OUTPUT` | Output directory for the archive | `/tmp` |
+| `--verbose` | `-v` | `BC_VERBOSE` | Verbose logging | `false` |
+
+## 📁 Output Structure
+
+BUTTCRACK produces a single timestamped archive preserving the original directory structure of all collected paths:
+
+```
+# Archive written to output directory:
+/tmp/buttcrack_logs_2025-11-12_14-30-00.tar.gz
+
+# Contents of the archive (original paths preserved):
+buttcrack_logs_2025-11-12_14-30-00/
+├── var/
+│   ├── lib/
+│   │   └── rancher/
+│   │       └── rke2/
+│   │           └── server/
+│   │               └── db/
+│   │                   └── etcd/
+│   │                       └── member/
+│   │                           ├── snap/
+│   │                           └── wal/
+│   └── log/
+│       └── pods/
+│           └── ...
+└── collection-summary.yaml
+```
+
+The `_logs_` infix in the archive name is intentional — it allows the existing `nessie_upload_logs.yaml` Ansible playbook in stack-validation to pick up BUTTCRACK archives with its `*logs*.tar.gz` glob without any changes.
+
+## 🏗️ Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                             INPUT                               │
+│                                                                 │
+│   CLI flags                       Env vars                      │
+│   --paths /var/lib/etcd,...        BC_PATHS              │
+│   --output /tmp                    BC_OUTPUT             │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                          BUTTCRACK                              │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ main.rs                                                   │  │
+│  │ parse args + env vars · orchestrate · logging             │  │
+│  └───────────────────────────┬───────────────────────────────┘  │
+│                              │                                  │
+│  ┌───────────────────────────▼───────────────────────────────┐  │
+│  │ collector.rs                                              │  │
+│  │ validate paths exist · walk each directory recursively    │  │
+│  │ build ordered file list                                   │  │
+│  └───────────────────────────┬───────────────────────────────┘  │
+│                              │                                  │
+│  ┌───────────────────────────▼───────────────────────────────┐  │
+│  │ archive.rs                                                │  │
+│  │ stream files into GzEncoder → tar::Builder                │  │
+│  │ write buttcrack_logs_<timestamp>.tar.gz to output dir     │  │
+│  └───────────────────────────┬───────────────────────────────┘  │
+│                              │                                  │
+└─────────────────────────────┼───────────────────────────────────┘
+                              │
+                              ▼
+                  buttcrack_logs_<timestamp>.tar.gz
+                              │
+┌─────────────────────────────┼───────────────────────────────────┐
+│              ANSIBLE / stack-validation                         │
+│                             │                                   │
+│  ┌───────────────────────────▼───────────────────────────────┐  │
+│  │ buttcrack_collect.yaml                                    │  │
+│  │ podman run --privileged                                   │  │
+│  │   -v /host/path:/host/path:ro   (per input path)         │  │
+│  │   -v /tmp:/tmp                  (output, rw)             │  │
+│  │                                                           │  │
+│  │ sed rename →                                             │  │
+│  │   buttcrack_<CLUSTER><CLUSTER_SUFFIX>_logs_<timestamp>    │  │
+│  └───────────────────────────┬───────────────────────────────┘  │
+│                              │                                  │
+│  ┌───────────────────────────▼───────────────────────────────┐  │
+│  │ nessie_upload_logs.yaml (reused as-is)                    │  │
+│  │ glob: *logs*.tar.gz · WebDAV PUT                          │  │
+│  └───────────────────────────┬───────────────────────────────┘  │
+│                              │                                  │
+└─────────────────────────────┼───────────────────────────────────┘
+                              │
+                              ▼
+                       WebDAV server
+                  /pipelines/<id>/logs/
+```
+
+## 💡 Common Use Cases
+
+### Collect etcd Database for Investigation
+```bash
+podman run --rm --privileged \
+           -v /var/lib/rancher/rke2/server/db/etcd:/var/lib/rancher/rke2/server/db/etcd:ro \
+           -v /tmp:/tmp \
+           buttcrack:latest \
+           --paths /var/lib/rancher/rke2/server/db/etcd --output /tmp
+```
+
+### Collect from k3s Instead
+```bash
+podman run --rm --privileged \
+           -v /var/lib/rancher/k3s/server/db/etcd:/var/lib/rancher/k3s/server/db/etcd:ro \
+           -v /tmp:/tmp \
+           buttcrack:latest \
+           --paths /var/lib/rancher/k3s/server/db/etcd --output /tmp
+```
+
+### Collect Multiple Diagnostic Paths
+```bash
+podman run --rm --privileged \
+           -v /var/lib/rancher/rke2/server/db/etcd:/var/lib/rancher/rke2/server/db/etcd:ro \
+           -v /var/log/pods:/var/log/pods:ro \
+           -v /tmp:/tmp \
+           buttcrack:latest \
+           --paths /var/lib/rancher/rke2/server/db/etcd,/var/log/pods \
+           --output /tmp --verbose
+```
+
+## 🔧 Development
+
+### Building from Source
+
+```bash
+# Debug build
+cargo build
+
+# Release build (optimized)
+cargo build --release
+
+# Run tests
+cargo test
+
+# Format code
+cargo fmt
+
+# Check for issues
+cargo clippy
+```
+
+### Project Structure
+
+```
+src/
+├── main.rs        # 🚪 CLI interface and orchestration
+├── collector.rs   # 📂 Path validation and recursive directory walking
+└── archive.rs     # 🗜️ tar.gz archive creation
+```
+
+## 🐛 Troubleshooting
+
+**🚫 "Path does not exist or is not accessible"**
+- Verify the path exists on the host: `ls -la /your/path`
+- Ensure the path is bind-mounted into the container with the same name
+- Check that the source path is not empty
+
+**📁 "Permission denied" on output**
+- Ensure the output directory is mounted with write access (no `:ro`)
+- Try using `/tmp` as the output directory
+
+**🔒 SELinux volume mount errors**
+- Add `:Z` to volume mounts on SELinux-enforcing systems:
+  ```bash
+  -v /your/path:/your/path:ro,Z
+  -v /tmp:/tmp:Z
+  ```
+
+**📦 Archive not picked up by upload playbook**
+- Verify the archive name contains `_logs_` — this is required by the `nessie_upload_logs.yaml` glob
+- Check the output directory matches `log_source_dir` passed to the upload playbook
+
+## 📄 License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](../LICENSE) file for details.
+
+This project is part of the SUSE Edge Support Tools collection.
+
+## 🙏 Acknowledgments
+
+- 🦀 Built with **Rust** for performance and safety
+- 🔌 Designed to integrate natively with **stack-validation** Ansible pipelines
+- 🍑 Named after a perfectly reasonable acronym, we promise
+
+---
+
+**Made with ❤️ and 🦀 by the SUSE Support Team**
+
+*Don't let your cluster data slip through the cracks!* 🍑✨

--- a/buttcrack/src/archive.rs
+++ b/buttcrack/src/archive.rs
@@ -1,0 +1,76 @@
+use crate::collector::CollectedEntry;
+use anyhow::{Context, Result};
+use std::fs;
+use tracing::info;
+
+pub fn create_archive(
+    entries: &[CollectedEntry],
+    source_paths: &[String],
+    output_dir: &str,
+    timestamp: &str,
+) -> Result<String> {
+    let archive_name = format!("{}/buttcrack_logs_{}.tar.gz", output_dir, timestamp);
+    let top_dir = format!("buttcrack_logs_{}", timestamp);
+
+    info!("Creating archive: {}", archive_name);
+
+    let tar_gz = fs::File::create(&archive_name).context("Failed to create archive file")?;
+    let enc = flate2::write::GzEncoder::new(tar_gz, flate2::Compression::default());
+    let mut tar = tar::Builder::new(enc);
+
+    let summary = build_summary(entries, source_paths, timestamp);
+    let summary_bytes = summary.as_bytes();
+    let mut header = tar::Header::new_gnu();
+    header.set_path(format!("{}/collection-summary.yaml", top_dir))?;
+    header.set_size(summary_bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    tar.append(&header, summary_bytes)
+        .context("Failed to add summary to archive")?;
+
+    for entry in entries {
+        let archive_path = format!("{}/{}", top_dir, entry.archive_path);
+
+        if entry.is_dir {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(&archive_path)?;
+            header.set_entry_type(tar::EntryType::Directory);
+            header.set_mode(0o755);
+            header.set_size(0);
+            header.set_cksum();
+            tar.append(&header, &[][..])
+                .context(format!("Failed to add directory: {}", archive_path))?;
+        } else {
+            tar.append_path_with_name(&entry.absolute_path, &archive_path)
+                .context(format!(
+                    "Failed to add file: {}",
+                    entry.absolute_path.display()
+                ))?;
+        }
+    }
+
+    tar.finish().context("Failed to finalize archive")?;
+
+    info!("Archive finalized: {}", archive_name);
+    Ok(archive_name)
+}
+
+fn build_summary(entries: &[CollectedEntry], source_paths: &[String], timestamp: &str) -> String {
+    let file_count = entries.iter().filter(|e| !e.is_dir).count();
+    let dir_count = entries.iter().filter(|e| e.is_dir).count();
+
+    let paths_yaml = source_paths
+        .iter()
+        .map(|p| format!("  - {}", p))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "collection_info:\n  timestamp: \"{}\"\n  tool: buttcrack\n  version: \"{}\"\n\npaths_collected:\n{}\n\ncollection_summary:\n  total_files: {}\n  total_directories: {}\n",
+        timestamp,
+        env!("CARGO_PKG_VERSION"),
+        paths_yaml,
+        file_count,
+        dir_count,
+    )
+}

--- a/buttcrack/src/collector.rs
+++ b/buttcrack/src/collector.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use std::os::unix::fs::FileTypeExt;
+use std::path::PathBuf;
+use tracing::{info, warn};
+use walkdir::WalkDir;
+
+pub struct CollectedEntry {
+    pub absolute_path: PathBuf,
+    pub archive_path: String,
+    pub is_dir: bool,
+}
+
+pub fn collect_paths(paths: &[String]) -> Result<Vec<CollectedEntry>> {
+    let mut entries = Vec::new();
+    let mut total_files = 0usize;
+
+    for path_str in paths {
+        let path = std::path::Path::new(path_str);
+
+        if !path.exists() {
+            warn!("Path does not exist, skipping: {}", path_str);
+            continue;
+        }
+
+        info!("Collecting: {}", path_str);
+
+        for entry in WalkDir::new(path).follow_links(false) {
+            match entry {
+                Ok(e) => {
+                    let ft = e.file_type();
+                    let path_display = e.path().display();
+
+                    if ft.is_symlink() {
+                        warn!(
+                            "Skipping {}: symlink — symlinks are not followed to prevent escaping the intended path or creating loops",
+                            path_display
+                        );
+                        continue;
+                    }
+
+                    if ft.is_fifo() {
+                        warn!(
+                            "Skipping {}: named pipe (FIFO) — reading a FIFO blocks forever waiting for a writer, skipping to avoid hang",
+                            path_display
+                        );
+                        continue;
+                    }
+
+                    if ft.is_socket() {
+                        warn!(
+                            "Skipping {}: Unix socket — opening a socket blocks indefinitely, skipping to avoid hang",
+                            path_display
+                        );
+                        continue;
+                    }
+
+                    if ft.is_block_device() {
+                        warn!(
+                            "Skipping {}: block device — raw block device reads are not supported",
+                            path_display
+                        );
+                        continue;
+                    }
+
+                    if ft.is_char_device() {
+                        warn!(
+                            "Skipping {}: character device — raw character device reads are not supported",
+                            path_display
+                        );
+                        continue;
+                    }
+
+                    let is_dir = ft.is_dir();
+                    let archive_path = e
+                        .path()
+                        .to_str()
+                        .unwrap_or("")
+                        .trim_start_matches('/')
+                        .to_string();
+
+                    if !is_dir {
+                        total_files += 1;
+                    }
+
+                    entries.push(CollectedEntry {
+                        absolute_path: e.path().to_path_buf(),
+                        archive_path,
+                        is_dir,
+                    });
+                }
+                Err(e) => {
+                    warn!("Skipping inaccessible entry: {}", e);
+                }
+            }
+        }
+    }
+
+    info!("Total files to archive: {}", total_files);
+    Ok(entries)
+}

--- a/buttcrack/src/main.rs
+++ b/buttcrack/src/main.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use chrono::Local;
+use clap::Parser;
+use tracing::{info, warn};
+
+mod archive;
+mod collector;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "buttcrack",
+    about = "Batch Utility To Transfer Cluster Resources And Configs Kit",
+    version
+)]
+struct Args {
+    /// Comma-separated list of host paths to collect
+    #[arg(short, long, env = "BC_PATHS", value_delimiter = ',', required = true)]
+    paths: Vec<String>,
+
+    /// Output directory for the archive
+    #[arg(short, long, env = "BC_OUTPUT", default_value = "/tmp")]
+    output: String,
+
+    /// Verbose logging
+    #[arg(short, long, env = "BC_VERBOSE", default_value_t = false)]
+    verbose: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let level = if args.verbose { "info" } else { "warn" };
+    tracing_subscriber::fmt()
+        .with_env_filter(level)
+        .without_time()
+        .init();
+
+    let timestamp = Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+
+    info!("Starting BUTTCRACK collection");
+    info!("Paths: {:?}", args.paths);
+    info!("Output: {}", args.output);
+
+    let entries = collector::collect_paths(&args.paths)?;
+
+    if entries.iter().all(|e| e.is_dir) {
+        warn!("No files found in the provided paths - archive will be empty");
+    }
+
+    let archive_path = archive::create_archive(&entries, &args.paths, &args.output, &timestamp)?;
+
+    info!("Archive created: {}", archive_path);
+    println!("{}", archive_path);
+
+    Ok(())
+}


### PR DESCRIPTION

  Rust CLI tool that collects arbitrary host paths and archives them into a
  timestamped tar.gz for upload and investigation. Designed to plug into
  stack-validation Ansible pipelines, following the same collection and upload
  pattern as nessie.

  - Accepts comma-separated paths via --paths / BC_PATHS
  - Streams collected files into a tar.gz preserving full directory structure
  - Safely skips special files (sockets, FIFOs, symlinks, devices) with descriptive warnings to aid debugging
  - Writes collection-summary.yaml as the first archive entry
  - Output naming follows nessie convention (*_logs_<timestamp>.tar.gz) for drop-in compatibility with nessie_upload_logs.yaml